### PR TITLE
Editorの中の文章を共有できるようにした

### DIFF
--- a/licc/src/components/LiveVideo.tsx
+++ b/licc/src/components/LiveVideo.tsx
@@ -45,7 +45,7 @@ export const LiveVideo = () => {
   return (
     <div style={{ display: "flex", height: "100vh" }}>
       {/* 左側：Monaco Editor */}
-      <SharedEditor />
+      <SharedEditor channelName={channelName!} />
 
       {/* 右側：ビデオコンポーネント */}
       <div style={{ display: "flex", height: "100vh" }}>

--- a/licc/src/components/LiveVideo.tsx
+++ b/licc/src/components/LiveVideo.tsx
@@ -10,7 +10,7 @@ import {
   useRemoteAudioTracks,
   useRemoteUsers,
 } from "agora-rtc-react";
-import { Editor } from "@monaco-editor/react";
+import SharedEditor from "./SharedEditor";
 
 export const LiveVideo = () => {
   const appId = 'fd57f12beae042569095bfc0ecc9f6b4';
@@ -42,26 +42,10 @@ export const LiveVideo = () => {
 
   audioTracks.forEach((track) => track.play());
 
-  // エディターのコード状態を管理
-  const [code, setCode] = useState("// ここにコードを入力");
-
   return (
     <div style={{ display: "flex", height: "100vh" }}>
       {/* 左側：Monaco Editor */}
-      <div id="editor">
-        <Editor
-          language="c"
-          value={code}
-          onChange={(newValue) => setCode(newValue || "")}
-          theme="vs-dark"
-          options={{
-            minimap: { enabled: false },
-            fontSize: 14,
-          }}
-          width="100%"
-          height="100%"
-        />
-      </div>
+      <SharedEditor />
 
       {/* 右側：ビデオコンポーネント */}
       <div style={{ display: "flex", height: "100vh" }}>

--- a/licc/src/components/SharedEditor.tsx
+++ b/licc/src/components/SharedEditor.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from "react";
+import { db } from "../FirebaseConfig";
+import { doc, setDoc, onSnapshot } from "firebase/firestore";
+import { Editor } from "@monaco-editor/react";
+
+const SharedEditor = ({channelName}) => {
+  const [code, setCode] = useState("");
+  const docRef = doc(db, "codes", channelName); // codesコレクションにチャンネル名のドキュメントを作成
+  
+  useEffect(() => {
+    // Firestoreのドキュメントをリアルタイムで監視
+    const unsubscribe = onSnapshot(docRef, (doc) => {
+      if (doc.exists()) {
+        setCode(doc.data().text);
+      }
+    });
+
+    return () => unsubscribe();
+  }, []);
+
+  const handleCodeChange = async (newCode: string | undefined) => {
+    if (newCode) {
+        setCode(newCode);
+        await setDoc(docRef, {Text: newCode});
+    }
+  }
+
+  return (
+    <div id="editor">
+      {channelName}
+      <Editor
+        language="c"
+        value={code}
+        onChange={handleCodeChange}
+        theme="vs-dark"
+        options={{
+          minimap: { enabled: false },
+          fontSize: 14,
+        }}
+        width="100%"
+        height="100%"
+      />
+    </div>
+  );
+};
+
+export default SharedEditor;


### PR DESCRIPTION
## 追加した機能
- コードを共有する機能を実装するために、Firebase Firestore Databaseを用いて共有できるようにした
- 同じチャンネル名に入れば、同じコードが表示される

## Firebaseを利用しようと思った理由
- データを共有するためのサーバーを用意する必要がない
- 無料プランで利用できる

## Firestoreの使いかた
1. Firebaseにプロジェクトを作成して、Firestoreのデータベースを作成する
2. プロジェクトの設定 > マイアプリ | SDK の設定と構成 からFirebaseConfigを取得する
3. `licc % npm install firebase`でローカルのプロジェクトにFirebaseをインストールする
4. ②で取得したAPI keyを.envファイルを作成して、exampleの様式で変数を入れる

## 修正をお願いしたいエラー
`SharedEditor`に`channelName`を渡しているときに型で怒られている

